### PR TITLE
Revert "Update glibc to 2.35-r0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN set -xeo pipefail && \
     wget -O "/etc/apk/keys/sgerrand.rsa.pub" \
       "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" && \
     wget -O "/tmp/glibc.apk" \
-      "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk" && \
+      "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk" && \
     wget -O "/tmp/glibc-bin.apk" \
-      "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-bin-2.35-r0.apk" && \
+      "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-bin-2.34-r0.apk" && \
     apk add "/tmp/glibc.apk" "/tmp/glibc-bin.apk" && \
     rm "/etc/apk/keys/sgerrand.rsa.pub" && \
     rm "/root/.wget-hsts" && \


### PR DESCRIPTION
Reverts DeviceFarmer/docker-adb#33
Fixes #34 